### PR TITLE
import sys.exit to allow exception-free exiting

### DIFF
--- a/pyPS4Controller/controller.py
+++ b/pyPS4Controller/controller.py
@@ -1,7 +1,7 @@
 import os
 import struct
 import time
-
+from sys import exit
 
 class Actions:
     """


### PR DESCRIPTION
There's an import of sys.exit in cli.py but for people using pyPS4Controller as a library it should be imported here too, otherwise the Controller causes exceptions when disconnecting.